### PR TITLE
RDISCROWD-2967: Remove webhook field from update form

### DIFF
--- a/templates/projects/update.html
+++ b/templates/projects/update.html
@@ -52,7 +52,6 @@
         {% if 'data_access' in form %}
             {{ render_select2_field(form.data_access, config.DATA_ACCESS_MESSAGE.replace('SHORT_NAME', project.short_name) if config.DATA_ACCESS_MESSAGE else None) }}
         {% endif %}
-        {{ render_field(form.webhook) }}
         <div class="form-actions">
             <button type="submit" name='btn' value="Save the changes" class="btn btn-primary">{{_('Save the changes')}}</button>
         </div>


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDISCROWD-2967*

**Describe your changes**
I removed line line  55, {{ render_field(form.webhook) }}, from update.html to hide the webhook entry field which is not currently being used.       

## Screenshots
### Before
![webhook](https://user-images.githubusercontent.com/4377042/80251218-3a768c80-8643-11ea-8cbb-182f06197dd5.png)

### After
<img width="930" alt="webhook_removed" src="https://user-images.githubusercontent.com/4377042/80251238-45312180-8643-11ea-895e-48898643713b.png">